### PR TITLE
Upate pyproject.toml. Support Python 3.10+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,21 @@ readme = "README.md"
 authors = [
     { name = "jonathan343", email = "jonathangee09@gmail.com" }
 ]
-requires-python = ">=3.14"
+requires-python = ">=3.10"
+classifiers = [
+  "Intended Audience :: Developers",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+]
 dependencies = []
 
 [build-system]


### PR DESCRIPTION
## Summary

This pull request updates the Python version requirements from 3.14+ to 3.10+ and adds PyPI classifiers for better package metadata on PyPI.

**Changes:**
- Updated `requires-python` from ">=3.14" to ">=3.10" to support Python 3.10 and later versions
- Added [PyPI classifiers](https://pypi.org/classifiers/) including Python version support (3.10-3.14), audience, OS compatibility, and implementation details