### PR TITLE
Add formatting check to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --group lint
       # Update output format to enable automatic inline annotations.
-      - name: Run Ruff
+      - name: Check linting
         run: uv run ruff check --output-format=github .
+      - name: Check formatting
+        run: uv run ruff format --check --output-format=github --preview .

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,10 +15,15 @@ def load_fixture():
         try:
             raw_text = fixture_path.read_text()
         except OSError as e:
-            raise FileNotFoundError(f"Failed to read fixture file '{fixture_path}': {e}") from e
+            raise FileNotFoundError(
+                f"Failed to read fixture file '{fixture_path}': {e}"
+            ) from e
 
         try:
             return json.loads(raw_text)
         except json.JSONDecodeError as e:
-            raise ValueError(f"Failed to parse JSON in fixture file '{fixture_path}': {e}") from e
+            raise ValueError(
+                f"Failed to parse JSON in fixture file '{fixture_path}': {e}"
+            ) from e
+
     return _load


### PR DESCRIPTION
## Summary

- Add r`uff format --check` step to the CI workflow to catch formatting issues in PRs
- Rename "Run Ruff" to "Check linting" for clarity now that both steps use ruff
- Enable `--output-format=github` for inline annotations and `--preview` for preview formatting rules

## Test plan

- Open a PR with unformatted code and verify the check fails with inline annotations

