### PR TITLE
Add test job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,18 @@ jobs:
         run: uv run ruff check --output-format=github .
       - name: Check formatting
         run: uv run ruff format --check --output-format=github --preview .
+
+  test:
+    runs-on: ubuntu-latest
+    name: Test
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7
+        with:
+          python-version-file: .python-version
+      - name: Install dependencies
+        run: uv sync --group test
+      - name: Run tests
+        run: uv run pytest


### PR DESCRIPTION
## Summary
- Add a new `test` job that runs pytest alongside the existing lint job

## Test plan
- [x] Verify CI workflow runs successfully on this PR
- [x] Confirm test job installs dependencies and runs pytest