### PR TITLE
Add GitHub Actions workflow for PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   pypi:
-    name: Publish to pypi
+    name: Publish to PyPI
     runs-on: ubuntu-latest
     # Environment and permissions for trusted publishing.
     environment:


### PR DESCRIPTION
## Summary

- Add automated package publishing workflow triggered by version tags (e.g., `v1.2.3`)
- Use [trusted publishing](https://docs.pypi.org/trusted-publishers/) with PyPI for secure, credential-free authentication
- Leverage uv for building and publishing the package

## Setup Required

Before using this workflow, configure trusted publishing:

1. **GitHub:** Create a `pypi` environment in repository settings (Settings → Environments)
2. **PyPI:** Add a trusted publisher in the project settings with:
     - Owner: `jonathan343`
     - Repository: `spotify-sdk`
     - Workflow: `release.yml`
     - Environment: `pypi`

## Usage

To publish a release:
```bash
git tag -a v0.1.0 -m "v0.1.0"
git push origin v0.1.0
```

## References

- https://docs.astral.sh/uv/guides/integration/github/#publishing-to-pypi