### PR TITLE
Fix docs build by running zensical through uv

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
         run: uv sync --group docs --no-default-groups
       
       - name: Build docs
-        run: zensical build --clean
+        run: uv run zensical build --clean
 
       - name: Setup Pages
         if: github.repository_owner == 'jonathan343'


### PR DESCRIPTION
## Summary

The initial docs build failed with the following error:

```
Run zensical build --clean
  zensical build --clean
  shell: /usr/bin/bash -e {0}
  env:
    UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
    UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
/home/runner/work/_temp/a3031c4f-7489-448c-a138-46848b180510.sh: line 1: zensical: command not found
```

The issue is we're using `zensical build --clean` and instead need to use `uv run zensical build --clean`