### PR TITLE
Add API reference docs with mkdocstrings integration

### DIFF
--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -1,0 +1,5 @@
+# Design
+
+System design notes and architecture decisions.
+
+- [Async-First Architecture with Unasync Code Generation](async-first-architecture.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,14 @@ icon: lucide/house
 
     [:octicons-arrow-right-24: Get started](quickstart.md)
 
+- __API Reference__
+
+    ---
+
+    Explore clients, services, and method signatures.
+
+    [:octicons-arrow-right-24: Reference](reference/index.md)
+
 - __Configuration__
 
     ---

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -78,8 +78,9 @@ asyncio.run(main())
 | Service | Description |
 |---------|-------------|
 | `client.albums` | Get albums, album tracks, and multiple albums |
-| `client.artists` | Get artists, artist albums, top tracks, and related artists |
-| `client.tracks` | Get tracks and audio features |
+| `client.artists` | Get artists, artist albums, and top tracks |
+| `client.playlists` | Get playlists, playlist items, and cover images |
+| `client.tracks` | Get tracks and multiple tracks |
 
 ## Configuration
 

--- a/docs/reference/clients.md
+++ b/docs/reference/clients.md
@@ -1,0 +1,85 @@
+---
+icon: lucide/terminal
+---
+
+# Clients
+
+The SDK exposes two entry points that share the same configuration:
+`SpotifyClient` for sync workflows and `AsyncSpotifyClient` for async
+workflows.
+
+## Construction
+
+Both clients accept the same constructor arguments.
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `access_token` | `str` | required | Spotify access token |
+| `timeout` | `float` | `30.0` | Request timeout in seconds |
+| `max_retries` | `int` | `3` | Maximum retries for transient errors |
+
+=== "Sync"
+
+    ```python
+    from spotify_sdk import SpotifyClient
+
+    client = SpotifyClient(
+        access_token="your-access-token",
+        timeout=30.0,
+        max_retries=3,
+    )
+    ```
+
+=== "Async"
+
+    ```python
+    from spotify_sdk import AsyncSpotifyClient
+
+    client = AsyncSpotifyClient(
+        access_token="your-access-token",
+        timeout=30.0,
+        max_retries=3,
+    )
+    ```
+
+## Lifecycle
+
+Use context managers to ensure connections are closed. You can also call
+`close()`/`await close()` directly.
+
+=== "Sync"
+
+    ```python
+    from spotify_sdk import SpotifyClient
+
+    with SpotifyClient(access_token="your-access-token") as client:
+        album = client.albums.get("7ycBtnsMtyVbbwTfJwRjSP")
+        print(album.name)
+    ```
+
+=== "Async"
+
+    ```python
+    import asyncio
+    from spotify_sdk import AsyncSpotifyClient
+
+    async def main() -> None:
+        async with AsyncSpotifyClient(access_token="your-access-token") as client:
+            album = await client.albums.get("7ycBtnsMtyVbbwTfJwRjSP")
+            print(album.name)
+
+    asyncio.run(main())
+    ```
+
+## Available services
+
+The main client exposes service objects as attributes:
+
+| Attribute | Description |
+| --- | --- |
+| `client.albums` | Album operations |
+| `client.artists` | Artist operations |
+| `client.playlists` | Playlist operations |
+| `client.tracks` | Track operations |
+
+See the full service reference for method-level details.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,39 @@
+# API Reference
+
+This section documents the public SDK surface area. Sync and async
+implementations share the same service names and method signatures, so the
+reference is grouped by service with code tabs for the sync and async styles.
+
+!!! note "Sync and async docs together"
+    The SDK is async-first internally, and the sync API is generated from it.
+    To avoid duplicate pages and keep examples aligned, the reference keeps
+    both variants on the same page using tabs. If a method ever diverges, the
+    sync or async tab will call it out explicitly.
+
+<div class="grid cards" markdown>
+
+- __Clients__
+
+    ---
+
+    Construction, lifecycle, and configuration for the main entry points.
+
+    [:octicons-arrow-right-24: Clients](clients.md)
+
+- __Services__
+
+    ---
+
+    Albums, artists, playlists, and tracks operations.
+
+    [:octicons-arrow-right-24: Services](services/index.md)
+
+- __Models__
+
+    ---
+
+    Pydantic models for Spotify API responses.
+
+    [:octicons-arrow-right-24: Models](models.md)
+
+</div>

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -1,0 +1,47 @@
+---
+icon: lucide/boxes
+---
+
+# Models
+
+Model classes are Pydantic-based representations of Spotify API responses.
+They are shared by sync and async clients.
+
+!!! note "Auto-generated reference"
+    The sections below are rendered from the source models to keep the
+    reference consistent with the SDK.
+
+## Album models
+
+::: spotify_sdk.models.album
+    options:
+        members: true
+        show_if_no_docstring: true
+
+## Artist models
+
+::: spotify_sdk.models.artist
+    options:
+        members: true
+        show_if_no_docstring: true
+
+## Playlist models
+
+::: spotify_sdk.models.playlist
+    options:
+        members: true
+        show_if_no_docstring: true
+
+## Track models
+
+::: spotify_sdk.models.track
+    options:
+        members: true
+        show_if_no_docstring: true
+
+## Common models
+
+::: spotify_sdk.models.common
+    options:
+        members: true
+        show_if_no_docstring: true

--- a/docs/reference/services/albums.md
+++ b/docs/reference/services/albums.md
@@ -1,0 +1,52 @@
+---
+icon: lucide/disc
+---
+
+# Albums
+
+Album operations live under `client.albums`.
+
+## Methods
+
+| Method | Returns | Description |
+| --- | --- | --- |
+| `get(id, market=None)` | `Album` | Fetch a single album by Spotify ID |
+| `get_several(ids, market=None)` | `list[Album]` | Fetch multiple albums (max 20 IDs) |
+| `get_tracks(id, market=None, limit=20, offset=0)` | `Page[SimplifiedTrack]` | Fetch tracks for an album |
+| `get_new_releases(limit=20, offset=0)` | `Page[SimplifiedAlbum]` | Fetch new album releases |
+
+!!! tip "Market parameter"
+    Pass an ISO 3166-1 alpha-2 country code to `market` when you need
+    relinking for regional availability.
+
+## Examples
+
+=== "Sync"
+
+    ```python
+    from spotify_sdk import SpotifyClient
+
+    with SpotifyClient(access_token="your-access-token") as client:
+        album = client.albums.get("7ycBtnsMtyVbbwTfJwRjSP")
+        tracks = client.albums.get_tracks(album.id, limit=10)
+    ```
+
+=== "Async"
+
+    ```python
+    import asyncio
+    from spotify_sdk import AsyncSpotifyClient
+
+    async def main() -> None:
+        async with AsyncSpotifyClient(access_token="your-access-token") as client:
+            album = await client.albums.get("7ycBtnsMtyVbbwTfJwRjSP")
+            tracks = await client.albums.get_tracks(album.id, limit=10)
+
+    asyncio.run(main())
+    ```
+
+## API details
+
+The sync client mirrors these methods, minus the `await` keywords.
+
+::: spotify_sdk._async.services.albums.AsyncAlbumService

--- a/docs/reference/services/artists.md
+++ b/docs/reference/services/artists.md
@@ -1,0 +1,60 @@
+---
+icon: lucide/mic-2
+---
+
+# Artists
+
+Artist operations live under `client.artists`.
+
+## Methods
+
+| Method | Returns | Description |
+| --- | --- | --- |
+| `get(id)` | `Artist` | Fetch an artist by Spotify ID |
+| `get_several(ids)` | `list[Artist]` | Fetch multiple artists (max 50 IDs) |
+| `get_albums(id, include_groups=None, market=None, limit=None, offset=None)` | `Page[SimplifiedAlbum]` | Fetch albums for an artist |
+| `get_top_tracks(id, market=None)` | `list[Track]` | Fetch an artist's top tracks |
+
+!!! tip "Filtering album types"
+    `include_groups` accepts the values `album`, `single`, `appears_on`, and
+    `compilation`. Pass a list to filter results.
+
+## Examples
+
+=== "Sync"
+
+    ```python
+    from spotify_sdk import SpotifyClient
+
+    with SpotifyClient(access_token="your-access-token") as client:
+        artist = client.artists.get("3TVXtAsR1Inumwj472S9r4")
+        albums = client.artists.get_albums(
+            artist.id,
+            include_groups=["album", "single"],
+            limit=10,
+        )
+    ```
+
+=== "Async"
+
+    ```python
+    import asyncio
+    from spotify_sdk import AsyncSpotifyClient
+
+    async def main() -> None:
+        async with AsyncSpotifyClient(access_token="your-access-token") as client:
+            artist = await client.artists.get("3TVXtAsR1Inumwj472S9r4")
+            albums = await client.artists.get_albums(
+                artist.id,
+                include_groups=["album", "single"],
+                limit=10,
+            )
+
+    asyncio.run(main())
+    ```
+
+## API details
+
+The sync client mirrors these methods, minus the `await` keywords.
+
+::: spotify_sdk._async.services.artists.AsyncArtistService

--- a/docs/reference/services/index.md
+++ b/docs/reference/services/index.md
@@ -1,0 +1,43 @@
+---
+icon: lucide/layers
+---
+
+# Services
+
+Each service wraps a portion of the Spotify Web API. Services are exposed as
+attributes on the client instance.
+
+!!! note "Auto-generated API details"
+    Each service page includes an auto-generated API section rendered from the
+    async implementation, which is the canonical source for the SDK.
+
+=== "Sync"
+
+    ```python
+    from spotify_sdk import SpotifyClient
+
+    with SpotifyClient(access_token="your-access-token") as client:
+        album = client.albums.get("7ycBtnsMtyVbbwTfJwRjSP")
+    ```
+
+=== "Async"
+
+    ```python
+    import asyncio
+    from spotify_sdk import AsyncSpotifyClient
+
+    async def main() -> None:
+        async with AsyncSpotifyClient(access_token="your-access-token") as client:
+            album = await client.albums.get("7ycBtnsMtyVbbwTfJwRjSP")
+
+    asyncio.run(main())
+    ```
+
+## Service list
+
+| Service | Description |
+| --- | --- |
+| [Albums](albums.md) | Album details, tracks, and new releases |
+| [Artists](artists.md) | Artist profiles, albums, and top tracks |
+| [Playlists](playlists.md) | Playlist details, items, and images |
+| [Tracks](tracks.md) | Track details and bulk lookups |

--- a/docs/reference/services/playlists.md
+++ b/docs/reference/services/playlists.md
@@ -1,0 +1,53 @@
+---
+icon: lucide/list-music
+---
+
+# Playlists
+
+Playlist operations live under `client.playlists`.
+
+## Methods
+
+| Method | Returns | Description |
+| --- | --- | --- |
+| `get(id, market=None, fields=None)` | `Playlist` | Fetch a playlist by ID |
+| `get_items(id, market=None, fields=None, limit=None, offset=None)` | `Page[PlaylistTrack]` | Fetch playlist items |
+| `get_for_current_user(limit=None, offset=None)` | `Page[SimplifiedPlaylist]` | Fetch playlists for the current user |
+| `get_for_user(id, limit=None, offset=None)` | `Page[SimplifiedPlaylist]` | Fetch playlists for a specific user |
+| `get_cover_image(id)` | `list[Image]` | Fetch playlist cover images |
+
+!!! tip "Field filtering"
+    The `fields` parameter supports Spotify's field filtering syntax, letting
+    you request a subset of fields for large playlist payloads.
+
+## Examples
+
+=== "Sync"
+
+    ```python
+    from spotify_sdk import SpotifyClient
+
+    with SpotifyClient(access_token="your-access-token") as client:
+        playlist = client.playlists.get("37i9dQZF1DXcBWIGoYBM5M")
+        items = client.playlists.get_items(playlist.id, limit=50)
+    ```
+
+=== "Async"
+
+    ```python
+    import asyncio
+    from spotify_sdk import AsyncSpotifyClient
+
+    async def main() -> None:
+        async with AsyncSpotifyClient(access_token="your-access-token") as client:
+            playlist = await client.playlists.get("37i9dQZF1DXcBWIGoYBM5M")
+            items = await client.playlists.get_items(playlist.id, limit=50)
+
+    asyncio.run(main())
+    ```
+
+## API details
+
+The sync client mirrors these methods, minus the `await` keywords.
+
+::: spotify_sdk._async.services.playlists.AsyncPlaylistService

--- a/docs/reference/services/tracks.md
+++ b/docs/reference/services/tracks.md
@@ -1,0 +1,50 @@
+---
+icon: lucide/music-2
+---
+
+# Tracks
+
+Track operations live under `client.tracks`.
+
+## Methods
+
+| Method | Returns | Description |
+| --- | --- | --- |
+| `get(id, market=None)` | `Track` | Fetch a track by Spotify ID |
+| `get_several(ids, market=None)` | `list[Track]` | Fetch multiple tracks (max 20 IDs) |
+
+## Examples
+
+=== "Sync"
+
+    ```python
+    from spotify_sdk import SpotifyClient
+
+    with SpotifyClient(access_token="your-access-token") as client:
+        track = client.tracks.get("3n3Ppam7vgaVa1iaRUc9Lp")
+        tracks = client.tracks.get_several(
+            ["3n3Ppam7vgaVa1iaRUc9Lp", "7ouMYWpwJ422jRcDASZB7P"],
+        )
+    ```
+
+=== "Async"
+
+    ```python
+    import asyncio
+    from spotify_sdk import AsyncSpotifyClient
+
+    async def main() -> None:
+        async with AsyncSpotifyClient(access_token="your-access-token") as client:
+            track = await client.tracks.get("3n3Ppam7vgaVa1iaRUc9Lp")
+            tracks = await client.tracks.get_several(
+                ["3n3Ppam7vgaVa1iaRUc9Lp", "7ouMYWpwJ422jRcDASZB7P"],
+            )
+
+    asyncio.run(main())
+    ```
+
+## API details
+
+The sync client mirrors these methods, minus the `await` keywords.
+
+::: spotify_sdk._async.services.tracks.AsyncTrackService

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,9 @@ codegen = [
   "unasync>=0.6.0",
 ]
 docs = [
-  "zensical>=0.0.19"
+  "zensical>=0.0.19",
+  "mkdocstrings-python>=1.10.0",
+  "griffe-pydantic>=1.1.0",
 ]
 dev = [
   {include-group = "lint"},

--- a/uv.lock
+++ b/uv.lock
@@ -119,6 +119,42 @@ wheels = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "griffe"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/0c/3a471b6e31951dce2360477420d0a8d1e00dea6cf33b70f3e8c3ab6e28e1/griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea", size = 424112, upload-time = "2025-11-10T15:03:15.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3", size = 150705, upload-time = "2025-11-10T15:03:13.549Z" },
+]
+
+[[package]]
+name = "griffe-pydantic"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/ef/045c7cfbd7c42dc99c5ae5da438f0ceeb3506937560f08c7511b375ee813/griffe_pydantic-1.2.0.tar.gz", hash = "sha256:e9a9b885daceaf164b3e25308217180f4f1fd99af4fa0a46882bfd8f66aae819", size = 34534, upload-time = "2026-01-13T14:11:35.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/af/109722a073c0abf02794e67429c0d834ca397e23f8bdd5d8322c3f3c9663/griffe_pydantic-1.2.0-py3-none-any.whl", hash = "sha256:9f287a883decbb76cccfdfbe72a659d8d97a46c95b008691c9c9cf9595068d4f", size = 13157, upload-time = "2026-01-13T14:11:34.295Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -293,6 +329,99 @@ wheels = [
 ]
 
 [[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-autorefs"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/fa/9124cd63d822e2bcbea1450ae68cdc3faf3655c69b455f3a7ed36ce6c628/mkdocs_autorefs-1.4.3.tar.gz", hash = "sha256:beee715b254455c4aa93b6ef3c67579c399ca092259cc41b7d9342573ff1fc75", size = 55425, upload-time = "2025-08-26T14:23:17.223Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/4d/7123b6fa2278000688ebd338e2a06d16870aaf9eceae6ba047ea05f92df1/mkdocs_autorefs-1.4.3-py3-none-any.whl", hash = "sha256:469d85eb3114801d08e9cc55d102b3ba65917a869b893403b8987b601cf55dc9", size = 25034, upload-time = "2025-08-26T14:23:15.906Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239, upload-time = "2023-11-20T17:51:09.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134", size = 9521, upload-time = "2023-11-20T17:51:08.587Z" },
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/4d/1ca8a9432579184599714aaeb36591414cc3d3bfd9d494f6db540c995ae4/mkdocstrings-1.0.2.tar.gz", hash = "sha256:48edd0ccbcb9e30a3121684e165261a9d6af4d63385fc4f39a54a49ac3b32ea8", size = 101048, upload-time = "2026-01-24T15:57:25.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/32/407a9a5fdd7d8ecb4af8d830b9bcdf47ea68f916869b3f44bac31f081250/mkdocstrings-1.0.2-py3-none-any.whl", hash = "sha256:41897815a8026c3634fe5d51472c3a569f92ded0ad8c7a640550873eea3b6817", size = 35443, upload-time = "2026-01-24T15:57:23.933Z" },
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffe" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/75/d30af27a2906f00eb90143470272376d728521997800f5dce5b340ba35bc/mkdocstrings_python-2.0.1.tar.gz", hash = "sha256:843a562221e6a471fefdd4b45cc6c22d2607ccbad632879234fa9692e9cf7732", size = 199345, upload-time = "2025-12-03T14:26:11.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/06/c5f8deba7d2cbdfa7967a716ae801aa9ca5f734b8f54fd473ef77a088dbe/mkdocstrings_python-2.0.1-py3-none-any.whl", hash = "sha256:66ecff45c5f8b71bf174e11d49afc845c2dfc7fc0ab17a86b6b337e0f24d8d90", size = 105055, upload-time = "2025-12-03T14:26:10.184Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -320,6 +449,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950, upload-time = "2024-11-08T09:47:47.202Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451, upload-time = "2024-11-08T09:47:44.722Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
 ]
 
 [[package]]
@@ -540,6 +687,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -604,6 +763,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.14.14"
 source = { registry = "https://pypi.org/simple" }
@@ -636,6 +807,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -673,7 +853,9 @@ codegen = [
 ]
 dev = [
     { name = "anyio", extra = ["trio"] },
+    { name = "griffe-pydantic" },
     { name = "jmeslog" },
+    { name = "mkdocstrings-python" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-httpx" },
@@ -682,6 +864,8 @@ dev = [
     { name = "zensical" },
 ]
 docs = [
+    { name = "griffe-pydantic" },
+    { name = "mkdocstrings-python" },
     { name = "zensical" },
 ]
 lint = [
@@ -710,7 +894,9 @@ codegen = [
 ]
 dev = [
     { name = "anyio", extras = ["trio"], specifier = ">=4.12.1" },
+    { name = "griffe-pydantic", specifier = ">=1.1.0" },
     { name = "jmeslog", specifier = ">=0.2.0" },
+    { name = "mkdocstrings-python", specifier = ">=1.10.0" },
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-httpx", specifier = ">=0.36.0" },
@@ -718,7 +904,11 @@ dev = [
     { name = "unasync", specifier = ">=0.6.0" },
     { name = "zensical", specifier = ">=0.0.19" },
 ]
-docs = [{ name = "zensical", specifier = ">=0.0.19" }]
+docs = [
+    { name = "griffe-pydantic", specifier = ">=1.1.0" },
+    { name = "mkdocstrings-python", specifier = ">=1.10.0" },
+    { name = "zensical", specifier = ">=0.0.19" },
+]
 lint = [{ name = "ruff", specifier = ">=0.14.13" }]
 test = [
     { name = "anyio", extras = ["trio"], specifier = ">=4.12.1" },
@@ -840,6 +1030,38 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/4e/735dbc0885ca197bcd80a2479ca24035627e2e768c784261fc7f1b8d7600/unasync-0.6.0.tar.gz", hash = "sha256:a9d01ace3e1068b20550ab15b7f9723b15b8bcde728bc1770bcb578374c7ee58", size = 18755, upload-time = "2024-05-03T11:14:58.312Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/b5/d2842541718ffa12060854735587543120a31ebc339435e0bd0faf368541/unasync-0.6.0-py3-none-any.whl", hash = "sha256:9cf7aaaea9737e417d8949bf9be55dc25fdb4ef1f4edc21b58f76ff0d2b9d73f", size = 9959, upload-time = "2024-05-03T11:14:56.17Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/56/90994d789c61df619bfc5ce2ecdabd5eeff564e1eb47512bd01b5e019569/watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26", size = 96390, upload-time = "2024-11-01T14:06:24.793Z" },
+    { url = "https://files.pythonhosted.org/packages/55/46/9a67ee697342ddf3c6daa97e3a587a56d6c4052f881ed926a849fcf7371c/watchdog-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bc64ab3bdb6a04d69d4023b29422170b74681784ffb9463ed4870cf2f3e66112", size = 88389, upload-time = "2024-11-01T14:06:27.112Z" },
+    { url = "https://files.pythonhosted.org/packages/44/65/91b0985747c52064d8701e1075eb96f8c40a79df889e59a399453adfb882/watchdog-6.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c897ac1b55c5a1461e16dae288d22bb2e412ba9807df8397a635d88f671d36c3", size = 89020, upload-time = "2024-11-01T14:06:29.876Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ad/d17b5d42e28a8b91f8ed01cb949da092827afb9995d4559fd448d0472763/watchdog-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c7ac31a19f4545dd92fc25d200694098f42c9a8e391bc00bdd362c5736dbf881", size = 87902, upload-time = "2024-11-01T14:06:53.119Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ca/c3649991d140ff6ab67bfc85ab42b165ead119c9e12211e08089d763ece5/watchdog-6.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9513f27a1a582d9808cf21a07dae516f0fab1cf2d7683a742c498b93eedabb11", size = 88380, upload-time = "2024-11-01T14:06:55.19Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]
 
 [[package]]

--- a/zensical.toml
+++ b/zensical.toml
@@ -11,6 +11,29 @@ repo_name = "jonathan343/spotify-sdk"
 repo_url = "https://github.com/jonathan343/spotify-sdk"
 # TODO: Update site_url when publishing docs
 site_url = "https://spotify-sdk.dev/"
+nav = [
+    {"Welcome" = "index.md"},
+    {"Installation" = "installation.md"},
+    {"Quickstart" = "quickstart.md"},
+    {"Reference" = [
+        "reference/index.md",
+        "reference/clients.md",
+        "reference/models.md",
+        {"Services" = [
+            "reference/services/index.md",
+            "reference/services/albums.md",
+            "reference/services/artists.md",
+            "reference/services/playlists.md",
+            "reference/services/tracks.md",
+        ]},
+    ]},
+    {"Design" = [
+        "design/index.md",
+        {"Architecture" = [
+            "design/async-first-architecture.md",
+        ]},
+    ]},
+]
 
 # Copyright
 copyright = """
@@ -78,7 +101,7 @@ features = [
     # Turn on this feature to expand all collapsible sections in the
     # navigation sidebar by default.
     # https://zensical.org/docs/setup/navigation/#navigation-expansion
-    # "navigation.expand",
+    "navigation.expand",
 
     # This feature turns on navigation elements in the footer that allow the
     # user to navigate to a next or previous page.
@@ -230,3 +253,18 @@ anchor_linenums = true
 # Required for content tabs
 [project.markdown_extensions.pymdownx.tabbed]
 alternate_style = true
+
+# ----------------------------------------------------------------------------
+# mkdocstrings for API reference rendering
+# ----------------------------------------------------------------------------
+[project.plugins.mkdocstrings.handlers.python]
+inventories = ["https://docs.python.org/3/objects.inv"]
+paths = ["src"]
+
+[project.plugins.mkdocstrings.handlers.python.options]
+docstring_style = "google"
+inherited_members = true
+show_source = false
+extensions = [
+    { griffe_pydantic = { schema = true } }
+]


### PR DESCRIPTION
## Summary:

- Add curated API reference pages for clients, services, and models.
- Integrate mkdocstrings + griffe-pydantic for auto-rendered API/model details.
- Define explicit nav ordering, add Design index, and expand nav sections by default.

Uploading api

https://github.com/user-attachments/assets/31caf8df-9d10-436a-8232-bd51b65af49f

## Details:

- API details render from async-first sources to keep signatures in sync.
- Models page is backed by Pydantic schema rendering via griffe-pydantic.
- Manual nav keeps Design grouped and last in the sidebar.

## Tests:

- Generated docs locally and verified output was expected.