### PR TITLE
Add changelog docs page

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,7 @@
+---
+icon: lucide/scroll-text
+---
+
+<!-- Loads the changelog from the repository root -->
+
+--8<-- "CHANGELOG.md"

--- a/zensical.toml
+++ b/zensical.toml
@@ -15,6 +15,7 @@ nav = [
     {"Welcome" = "index.md"},
     {"Installation" = "installation.md"},
     {"Quickstart" = "quickstart.md"},
+    {"Changelog" = "changelog.md"},
     {"Reference" = [
         "reference/index.md",
         "reference/clients.md",
@@ -259,6 +260,9 @@ anchor_linenums = true
 # Required for content tabs
 [project.markdown_extensions.pymdownx.tabbed]
 alternate_style = true
+
+# Snippets: embed content from arbitrary files via simple syntax.
+[project.markdown_extensions.pymdownx.snippets]
 
 # ----------------------------------------------------------------------------
 # mkdocstrings for API reference rendering


### PR DESCRIPTION
## Overview

This PR adds a docs page that surfaces the repository `CHANGELOG.md` in the site navigation and enables snippets to embed the changelog content, making release notes visible in the published docs.

## Summary

- Add `docs/changelog.md` that includes the root `CHANGELOG.md` via snippets
- Add the Changelog page to the docs nav
- Enable `pymdownx.snippets` in `zensical.toml` to support the embed

## Testing

- `zensical serve -o`
<img width="1512" height="744" alt="Screenshot 2026-02-04 at 7 54 20 PM" src="https://github.com/user-attachments/assets/667c62c7-c3c6-48e0-8198-aa11da02c8af" />
