### PR TITLE
Revert "Bump pygments from 2.19.2 to 2.20.0 (#83)"

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -619,11 +619,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.20.0"
+version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> This reverts commit 934ac8f1c1fc52a6de4b26ee6611f94f967a1a9a.

## Summary
Updating pygments to v2.20.0 started silently breaking our docs builds. Unfortunately, zensical continued as normal after the errors which masked the failures and broke the docs site.

Example job:
https://github.com/jonathan343/spotify-sdk/actions/runs/23765417464/job/69243472590

Failure:

```
Run uv run zensical build --clean
  uv run zensical build --clean
  shell: /usr/bin/bash -e {0}
  env:
    UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
    UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
Downloading setuptools (1.0MiB)
Downloading pyright (6.1MiB)
Downloading ruff (10.8MiB)
 Downloaded ruff
 Downloaded setuptools
 Downloaded pyright
Installed 15 packages in 265ms
Build started
Error: AttributeError: 'NoneType' object has no attribute 'replace'
Error: AttributeError: 'NoneType' object has no attribute 'replace'
Error: AttributeError: 'NoneType' object has no attribute 'replace'
Error: AttributeError: 'NoneType' object has no attribute 'replace'
Error: AttributeError: 'NoneType' object has no attribute 'replace'
Build finished in 1.42s
```

## Testing

```
(spotify-sdk) $ zensical build
Build started
+ /
+ /changelog/
+ /design/
+ /reference/services/search/
+ /reference/services/users/
+ /reference/services/audiobooks/
+ /design/auth/client-credentials/
+ /reference/services/tracks/
+ /reference/
+ /installation/
+ /reference/services/playlists/
+ /reference/services/albums/
+ /reference/auth/
+ /reference/services/library/
+ /reference/services/artists/
+ /reference/models/
+ /reference/services/
+ /reference/clients/
+ /reference/services/shows/
+ /reference/services/chapters/
+ /quickstart/
+ /reference/services/player/
+ /design/async-first-architecture/
+ /design/auth/authorization-code-refresh-token/
+ /reference/services/episodes/
Build finished in 0.10s
```

## What's Next
When I get more time, I'll do a deeper dive into:
- Why zensical didn't return an error code
- Why pygments v2.20.0 starts causing this to fail


