### PR TITLE
Fix pyright errors with anyio 4.14

### DIFF
--- a/src/spotify_sdk/_async/auth/__init__.py
+++ b/src/spotify_sdk/_async/auth/__init__.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
 import base64
-import inspect
 import os
 import random
 import secrets
@@ -12,13 +10,12 @@ import threading
 import time
 import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any, Awaitable, Callable, Coroutine, Protocol, TypeVar, cast
+from typing import Any, Callable, Protocol, cast
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import anyio
 import httpx
 import sniffio
-from anyio import from_thread
 
 from ..._auth_shared import (
     FileTokenCache as FileTokenCache,
@@ -27,6 +24,7 @@ from ..._auth_shared import (
     InMemoryTokenCache,
     TokenCache,
     TokenInfo,
+    resolve_awaitable,
 )
 from ...exceptions import AuthenticationError, ServerError, SpotifyError
 
@@ -36,7 +34,6 @@ ENV_CLIENT_ID = "SPOTIFY_SDK_CLIENT_ID"
 ENV_CLIENT_SECRET = "SPOTIFY_SDK_CLIENT_SECRET"
 ENV_REDIRECT_URI = "SPOTIFY_SDK_REDIRECT_URI"
 
-_T = TypeVar("_T")
 _SUCCESS_HTML = """\
 <html>
   <head><title>Spotify SDK Authorization Complete</title></head>
@@ -592,7 +589,7 @@ def authorize_local(
         callback_path,
         expected_state=resolved_state,
     )
-    return _resolve_awaitable(auth.exchange_code(code))
+    return resolve_awaitable(auth.exchange_code(code))
 
 
 def _wait_for_local_callback(
@@ -641,20 +638,6 @@ def _wait_for_local_callback(
         server.shutdown()
         server.server_close()
         thread.join(timeout=1.0)
-
-
-def _resolve_awaitable(value: _T | Awaitable[_T]) -> _T:
-    if inspect.isawaitable(value):
-        awaitable = cast(Awaitable[_T], value)
-        try:
-            return from_thread.run(_return_awaitable, awaitable)
-        except RuntimeError:
-            return asyncio.run(cast(Coroutine[Any, Any, _T], awaitable))
-    return value
-
-
-def _return_awaitable(value: Awaitable[_T]) -> Awaitable[_T]:
-    return value
 
 
 def _is_running_in_event_loop() -> bool:

--- a/src/spotify_sdk/_auth_shared.py
+++ b/src/spotify_sdk/_auth_shared.py
@@ -1,13 +1,19 @@
-"""Shared auth cache types used by sync and async auth providers."""
+"""Shared auth types and helpers used by sync and async auth providers."""
 
 from __future__ import annotations
 
+import asyncio
+import inspect
 import json
 import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Awaitable, Protocol, TypeVar, cast
+
+from anyio import from_thread
+
+_T = TypeVar("_T")
 
 
 @dataclass(frozen=True)
@@ -102,3 +108,18 @@ class FileTokenCache:
             os.chmod(self._path, 0o600)
         except OSError:
             pass
+
+
+def resolve_awaitable(value: _T | Awaitable[_T]) -> _T:
+    """Return ``value``, awaiting it first if it is awaitable."""
+    if inspect.isawaitable(value):
+        awaitable = cast(Awaitable[_T], value)
+        try:
+            return from_thread.run(_await_awaitable, awaitable)
+        except RuntimeError:
+            return asyncio.run(_await_awaitable(awaitable))
+    return value
+
+
+async def _await_awaitable(value: Awaitable[_T]) -> _T:
+    return await value

--- a/src/spotify_sdk/_sync/auth/__init__.py
+++ b/src/spotify_sdk/_sync/auth/__init__.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
 import base64
-import inspect
 import os
 import random
 import secrets
@@ -12,12 +10,11 @@ import threading
 import time
 import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any, Awaitable, Callable, Coroutine, Protocol, TypeVar, cast
+from typing import Any, Callable, Protocol, cast
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
 import sniffio
-from anyio import from_thread
 
 from ..._auth_shared import (
     FileTokenCache as FileTokenCache,
@@ -26,6 +23,7 @@ from ..._auth_shared import (
     InMemoryTokenCache,
     TokenCache,
     TokenInfo,
+    resolve_awaitable,
 )
 from ...exceptions import AuthenticationError, ServerError, SpotifyError
 
@@ -35,7 +33,6 @@ ENV_CLIENT_ID = "SPOTIFY_SDK_CLIENT_ID"
 ENV_CLIENT_SECRET = "SPOTIFY_SDK_CLIENT_SECRET"
 ENV_REDIRECT_URI = "SPOTIFY_SDK_REDIRECT_URI"
 
-_T = TypeVar("_T")
 _SUCCESS_HTML = """\
 <html>
   <head><title>Spotify SDK Authorization Complete</title></head>
@@ -591,7 +588,7 @@ def authorize_local(
         callback_path,
         expected_state=resolved_state,
     )
-    return _resolve_awaitable(auth.exchange_code(code))
+    return resolve_awaitable(auth.exchange_code(code))
 
 
 def _wait_for_local_callback(
@@ -640,20 +637,6 @@ def _wait_for_local_callback(
         server.shutdown()
         server.server_close()
         thread.join(timeout=1.0)
-
-
-def _resolve_awaitable(value: _T | Awaitable[_T]) -> _T:
-    if inspect.isawaitable(value):
-        awaitable = cast(Awaitable[_T], value)
-        try:
-            return from_thread.run(_return_awaitable, awaitable)
-        except RuntimeError:
-            return asyncio.run(cast(Coroutine[Any, Any, _T], awaitable))
-    return value
-
-
-def _return_awaitable(value: Awaitable[_T]) -> Awaitable[_T]:
-    return value
 
 
 def _is_running_in_event_loop() -> bool:


### PR DESCRIPTION
## Overview

The Type Check job fails on the dependabot python-group PR (#113) because anyio 4.14.0 tightened the type annotation of `anyio.from_thread.run()` to only accept callables that return coroutines, reverting an annotation loosened in error back in anyio v3.7.0 ([agronholm/anyio#1153](https://github.com/agronholm/anyio/pull/1153)). Our `_resolve_awaitable` helper in the auth modules passed it `_return_awaitable`, a plain function returning `Awaitable[_T]`, which no longer satisfies the annotation:

```
src/spotify_sdk/_async/auth/__init__.py:650:36 - error: Argument of type "(value: Awaitable[_T@_return_awaitable]) -> Awaitable[_T@_return_awaitable]" cannot be assigned to parameter "func" of type "(*PosArgsT@run) -> Coroutine[Any, Any, T_co@run]" in function "run"
```

The idiomatic fix is to pass a real `async def` wrapper, but that can't live in `_async/` because unasync strips `async`/`await` tokens when generating the sync variant, which would mangle the helper into a broken plain function. The helper is a synchronous bridge that's identical in both variants anyway, so this PR moves it into `_auth_shared.py` (hand-written, not processed by unasync) as `resolve_awaitable` and writes it the way anyio expects:

```python
def resolve_awaitable(value: _T | Awaitable[_T]) -> _T:
    """Return ``value``, awaiting it first if it is awaitable."""
    if inspect.isawaitable(value):
        awaitable = cast(Awaitable[_T], value)
        try:
            return from_thread.run(_await_awaitable, awaitable)
        except RuntimeError:
            return asyncio.run(_await_awaitable(awaitable))
    return value


async def _await_awaitable(value: Awaitable[_T]) -> _T:
    return await value
```

Both auth modules now import it from there instead of carrying local copies. As a side benefit, the `asyncio.run` fallback previously relied on `cast(Coroutine[Any, Any, _T], awaitable)`, which was only true for coroutine objects; `await value` in the new wrapper handles any awaitable.

**Why does this typecheck against both anyio versions?** An `async def` returns `Coroutine`, which satisfies the new 4.14.0 signature and is also assignable to the old awaitable-accepting one, so this can merge to main (still on anyio 4.13.0) without breaking CI, and #113 goes green after a rebase.

## Testing

`scripts/run_unasync.py` was executed to regenerate the sync module.

```console
$ uv run python scripts/run_unasync.py --check
Sync check passed: no drift detected.

$ uv run pyright  # anyio 4.13.0 (current lock)
0 errors, 0 warnings, 0 informations

$ uv run --with anyio==4.14.0 pyright  # version bumped in #113
0 errors, 0 warnings, 0 informations

$ uv run ruff check . && uv run ruff format --check --preview .
All checks passed!
131 files already formatted

$ uv run pytest
512 passed, 1 skipped, 12 deselected in 3.80s
```

## Next Steps

After this merges, comment `@dependabot rebase` on #113 to pick up the fix.
